### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "pip install discord.py"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # watson-bot
 Personalised Discord Bot named Watson.
+
+Developed in repl.it : 
+[![Run on Repl.it](https://repl.it/badge/github/Anuj-Attri/watson-bot)](https://repl.it/github/Anuj-Attri/watson-bot)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).